### PR TITLE
fix(exec issue): Fix the private file paths command for the redeclare…

### DIFF
--- a/manifests/site.pp
+++ b/manifests/site.pp
@@ -186,13 +186,13 @@ define drupalsi::site ($profile,
       checksum => 'none',
     }
 
-    exec { "enforce drupalsi-private-dir-${privdir} permissions":
+    exec { "enforce drupalsi-private-dir-${name} permissions":
       command => "/bin/chown ${webserver_user}:${webserver_user} ${privdir}",
       require => File["drupalsi-private-dir-${name}"],
     }
 
     # Make sure the file permissions on the htaccess file are different from the rest
-    file {"drupalsi-private-dir-${privdir}-htaccess":
+    file {"drupalsi-private-dir-${name}-htaccess":
       path => "${privdir}/.htaccess",
       ensure => 'present',
       mode => '0444',


### PR DESCRIPTION
… collision.

If multiple sites exist a duplicate error occurs.

Error: Could not retrieve catalog from remote server: Error 400 on SERVER: Duplicate declaration: Exec[enforce drupalsi-private-dir-/var/www/html/drupal/sites/default/files/private permissions] is already declared in file /etc/puppet/environments/dropfort/modules/drupalsi/manifests/site.pp:192; cannot redeclare at /etc/puppet/environments/dropfort/modules/drupalsi/manifests/site.pp:192 on node c1aba2b6-1f75-41f3-a311-60f791137adb.dropfort.com