### PR TITLE
Feat (permissions) Add execute to drupal console binary file.

### DIFF
--- a/templates/drupal-fix-permissions.sh.erb
+++ b/templates/drupal-fix-permissions.sh.erb
@@ -112,6 +112,11 @@ find . -type f -exec chmod u=rw,g=r,o= '{}' \;
 if [[ "$drupal_version" -eq 8 ]]; then
   printf "Changing permissions of "vendor/bin" directories in "${d8_vendor}" to "rwxr-----"...\n"
   chmod u+x ${d8_vendor}/bin/* || true
+
+  # Other exceptions if they exist.
+  if [ -f ${d8_vendor}/drupal/console/bin/drupal ]; then
+    chmod u+x ${d8_vendor}/drupal/console/bin/drupal
+  fi
 fi
 
 # For D7 or D8 ensure we are now operating within the actual drupal dir.


### PR DESCRIPTION
@NickDJM Hi Nick, can you double check this please?

FYI $d8_vendor is being set here: https://github.com/coldfrontlabs/coldfrontlabs-drupalsi/blob/fef4cef4cdd4f6ec9d4e0b55db0811fa14a1dea7/templates/drupal-fix-permissions.sh.erb#L86